### PR TITLE
Update owner of storefront-permissions-ui to te-0010

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,4 +9,4 @@ spec:
   system: b2b-suite
   type: frontend-ui
   lifecycle: maintenance
-  owner: b-2-b-enabler
+  owner: te-0010


### PR DESCRIPTION
This PR updates the owner of storefront-permissions-ui to te-0010 in the catalog-info.yaml file.
This is necessary because now in DK Portal we will define the team -> component relationship through the team id instead of the owner name.